### PR TITLE
Adjust site theme to monochrome palette

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -47,10 +47,10 @@ export function Hero() {
             Ver Catálogo
           </Button>
           
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             size="xl"
-            className="min-w-[200px] border-white/30 text-black hover:bg-black/10"
+            className="min-w-[200px] border-white/40 text-white hover:bg-white/10"
             onClick={() => scrollToSection('contato')}
           >
             Falar Conosco

--- a/src/index.css
+++ b/src/index.css
@@ -9,102 +9,102 @@ All colors MUST be HSL.
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 0 0% 10%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 0 0% 12%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 0 0% 12%;
 
-    /* Brand colors inspired by the logo */
-    --primary: 220 100% 20%;
-    --primary-foreground: 0 0% 100%;
+    /* Brand colors inspired by the monochrome logo */
+    --primary: 0 0% 10%;
+    --primary-foreground: 0 0% 98%;
 
-    --secondary: 196 100% 50%;
-    --secondary-foreground: 220 100% 20%;
+    --secondary: 0 0% 22%;
+    --secondary-foreground: 0 0% 96%;
 
-    --muted: 220 14% 96%;
-    --muted-foreground: 220 9% 46%;
+    --muted: 0 0% 95%;
+    --muted-foreground: 0 0% 38%;
 
-    --accent: 14 100% 57%;
-    --accent-foreground: 0 0% 100%;
+    --accent: 0 0% 16%;
+    --accent-foreground: 0 0% 96%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 220 13% 91%;
-    --input: 220 13% 91%;
-    --ring: 220 100% 20%;
+    --border: 0 0% 85%;
+    --input: 0 0% 85%;
+    --ring: 0 0% 12%;
 
     --radius: 0.75rem;
 
     /* Custom design tokens */
-    --gradient-primary: linear-gradient(135deg, hsl(220 100% 20%), hsl(240 100% 25%));
-    --gradient-secondary: linear-gradient(135deg, hsl(196 100% 50%), hsl(285 100% 50%));
-    --gradient-accent: linear-gradient(135deg, hsl(14 100% 57%), hsl(30 100% 50%));
-    --gradient-hero: linear-gradient(135deg, hsl(220 100% 20%) 0%, hsl(240 100% 25%) 50%, hsl(196 100% 50%) 100%);
-    
-    --shadow-soft: 0 4px 20px hsl(220 100% 20% / 0.1);
-    --shadow-medium: 0 8px 30px hsl(220 100% 20% / 0.15);
-    --shadow-strong: 0 12px 40px hsl(220 100% 20% / 0.2);
+    --gradient-primary: linear-gradient(135deg, hsl(0 0% 12%), hsl(0 0% 2%));
+    --gradient-secondary: linear-gradient(135deg, hsl(0 0% 22%), hsl(0 0% 36%));
+    --gradient-accent: linear-gradient(135deg, hsl(0 0% 16%), hsl(0 0% 30%));
+    --gradient-hero: linear-gradient(135deg, hsl(0 0% 0%) 0%, hsl(0 0% 12%) 50%, hsl(0 0% 28%) 100%);
+
+    --shadow-soft: 0 4px 20px hsl(0 0% 0% / 0.1);
+    --shadow-medium: 0 8px 30px hsl(0 0% 0% / 0.15);
+    --shadow-strong: 0 12px 40px hsl(0 0% 0% / 0.2);
 
     --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     --transition-bounce: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 
     --sidebar-background: 0 0% 98%;
 
-    --sidebar-foreground: 240 5.3% 26.1%;
+    --sidebar-foreground: 0 0% 20%;
 
-    --sidebar-primary: 240 5.9% 10%;
+    --sidebar-primary: 0 0% 10%;
 
     --sidebar-primary-foreground: 0 0% 98%;
 
-    --sidebar-accent: 240 4.8% 95.9%;
+    --sidebar-accent: 0 0% 92%;
 
-    --sidebar-accent-foreground: 240 5.9% 10%;
+    --sidebar-accent-foreground: 0 0% 10%;
 
-    --sidebar-border: 220 13% 91%;
+    --sidebar-border: 0 0% 85%;
 
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-ring: 0 0% 28%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    --background: 0 0% 6%;
+    --foreground: 0 0% 96%;
 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
+    --card: 0 0% 10%;
+    --card-foreground: 0 0% 96%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 0 0% 8%;
+    --popover-foreground: 0 0% 96%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 0 0% 96%;
+    --primary-foreground: 0 0% 10%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 0 0% 22%;
+    --secondary-foreground: 0 0% 96%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 0 0% 22%;
+    --muted-foreground: 0 0% 70%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 0 0% 26%;
+    --accent-foreground: 0 0% 96%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --border: 0 0% 20%;
+    --input: 0 0% 20%;
+    --ring: 0 0% 65%;
+    --sidebar-background: 0 0% 8%;
+    --sidebar-foreground: 0 0% 92%;
+    --sidebar-primary: 0 0% 92%;
+    --sidebar-primary-foreground: 0 0% 10%;
+    --sidebar-accent: 0 0% 14%;
+    --sidebar-accent-foreground: 0 0% 92%;
+    --sidebar-border: 0 0% 14%;
+    --sidebar-ring: 0 0% 65%;
   }
 }
 


### PR DESCRIPTION
## Summary
- retune the global design tokens to a monochrome palette that matches the Apple-G branding
- update the hero secondary action styling for better contrast against the darkened hero overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1ce4649448323978a80dba8e73a7e